### PR TITLE
Upgrade for terraform compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.tfstate
 *.tfstate.*
 
+# terraform lock
+.terraform.lock.hcl
+
 # Crash log files
 crash.log
 

--- a/README.md
+++ b/README.md
@@ -10,3 +10,56 @@ To establish a chain of trust for DNSSEC, you must update the parent zone for yo
 Error: Variables not allowed: Variables may not be used here.
 
 <!--- END_TF_DOCS --->
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.51.0 |
+| <a name="provider_aws.kms"></a> [aws.kms](#provider\_aws.kms) | 4.51.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_kms_key.dnssec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_route53_hosted_zone_dnssec.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_hosted_zone_dnssec) | resource |
+| [aws_route53_key_signing_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_key_signing_key) | resource |
+| [aws_route53_zone.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.dnssec_signing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_comment"></a> [comment](#input\_comment) | A comment for the hosted zone. Defaults to 'Managed by Terraform' | `string` | `null` | no |
+| <a name="input_delegation_set_id"></a> [delegation\_set\_id](#input\_delegation\_set\_id) | The ID of the reusable delegation set whose NS records you want to assign to the hosted zone. Conflicts with vpc as delegation sets can only be used for public zones | `string` | `null` | no |
+| <a name="input_dnssec"></a> [dnssec](#input\_dnssec) | Wheter or not to enable DNSSEC signing for this zone | `bool` | `false` | no |
+| <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Whether to destroy all records (possibly managed outside of Terraform) in the zone when destroying the zone | `bool` | `false` | no |
+| <a name="input_kms_signing_key_settings"></a> [kms\_signing\_key\_settings](#input\_kms\_signing\_key\_settings) | KMS Key settings used for zone signing | <pre>object({<br>    deletion_window_in_days = optional(number, 30)<br>  })</pre> | `{}` | no |
+| <a name="input_name"></a> [name](#input\_name) | The hosted zone name | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to set on Terraform created resources | `map(string)` | `{}` | no |
+| <a name="input_vpc"></a> [vpc](#input\_vpc) | n/a | <pre>map(object({<br>    vpc_id     = string<br>    vpc_region = string<br>  }))</pre> | <pre>{<br>  "key": {<br>    "vpc_id": null,<br>    "vpc_region": null<br>  }<br>}</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_route53_zone_name"></a> [route53\_zone\_name](#output\_route53\_zone\_name) | Name of Route53 zone |
+| <a name="output_route53_zone_name_servers"></a> [route53\_zone\_name\_servers](#output\_route53\_zone\_name\_servers) | Name servers of Route53 zone |
+| <a name="output_route53_zone_zone_id"></a> [route53\_zone\_zone\_id](#output\_route53\_zone\_zone\_id) | Zone ID of Route53 zone |
+<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -7,39 +7,6 @@ Terraform module to setup and manage route53 zones.
 To establish a chain of trust for DNSSEC, you must update the parent zone for your hosted zone with a DNSSEC 'DS' record.
 
 <!--- BEGIN_TF_DOCS --->
-## Requirements
-
-| Name | Version |
-|------|---------|
-| terraform | >= 0.13.1 |
-| aws | >= 3.67 |
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| aws | >= 3.67 |
-| aws.kms | >= 3.67 |
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| name | The hosted zone name | `string` | n/a | yes |
-| tags | Map of tags to set on Terraform created resources | `map(string)` | n/a | yes |
-| comment | A comment for the hosted zone. Defaults to 'Managed by Terraform' | `string` | `null` | no |
-| delegation\_set\_id | The ID of the reusable delegation set whose NS records you want to assign to the hosted zone. Conflicts with vpc as delegation sets can only be used for public zones | `string` | `null` | no |
-| dnssec | Wheter or not to enable DNSSEC signing for this zone | `bool` | `false` | no |
-| force\_destroy | Whether to destroy all records (possibly managed outside of Terraform) in the zone when destroying the zone | `bool` | `false` | no |
-| kms\_signing\_key\_settings | KMS Key settings used for zone signing | <pre>object({<br>    deletion_window_in_days = optional(number, 30)<br>  })</pre> | `{}` | no |
-| vpc | n/a | <pre>map(object({<br>    vpc_id     = string<br>    vpc_region = string<br>  }))</pre> | <pre>{<br>  "key": {<br>    "vpc_id": null,<br>    "vpc_region": null<br>  }<br>}</pre> | no |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| route53\_zone\_name | Name of Route53 zone |
-| route53\_zone\_name\_servers | Name servers of Route53 zone |
-| route53\_zone\_zone\_id | Zone ID of Route53 zone |
+Error: Variables not allowed: Variables may not be used here.
 
 <!--- END_TF_DOCS --->

--- a/dnssec.tf
+++ b/dnssec.tf
@@ -1,8 +1,3 @@
-provider "aws" {
-  alias  = "kms"
-  region = "us-east-1"
-}
-
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "dnssec_signing" {

--- a/dnssec.tf
+++ b/dnssec.tf
@@ -1,11 +1,12 @@
 data "aws_caller_identity" "current" {}
+data "aws_region" "default" {}
 
 data "aws_iam_policy_document" "dnssec_signing" {
   statement {
     sid       = "Enable IAM User Permissions"
     actions   = ["kms:*"]
     effect    = "Allow"
-    resources = ["*"]
+    resources = ["arn:aws:kms:${data.aws_region.default.name}:${data.aws_caller_identity.current.account_id}:key/*"]
 
     principals {
       type        = "AWS"
@@ -21,7 +22,7 @@ data "aws_iam_policy_document" "dnssec_signing" {
       "kms:Sign",
     ]
     effect    = "Allow"
-    resources = ["*"]
+    resources = ["arn:aws:kms:${data.aws_region.default.name}:${data.aws_caller_identity.current.account_id}:key/*"]
 
     condition {
       test     = "StringEquals"
@@ -45,7 +46,7 @@ data "aws_iam_policy_document" "dnssec_signing" {
     sid       = "Allow Route 53 DNSSEC to CreateGrant"
     actions   = ["kms:CreateGrant"]
     effect    = "Allow"
-    resources = ["*"]
+    resources = ["arn:aws:kms:${data.aws_region.default.name}:${data.aws_caller_identity.current.account_id}:key/*"]
 
     condition {
       test     = "Bool"

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
 resource "aws_route53_zone" "default" {
+  # https://github.com/bridgecrewio/checkov/issues/3562#issuecomment-1256892542
+  #checkov:skip=CKV2_AWS_39: "Ensure Domain Name System (DNS) query logging is enabled for Amazon Route 53 hosted zones"
   name              = var.name
   comment           = var.comment
   force_destroy     = var.force_destroy

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,8 @@ output "route53_zone_name" {
   description = "Name of Route53 zone"
   value       = aws_route53_zone.default.name
 }
+
+output "route53_zone_arn" {
+  description = "ARN of Route53 zone"
+  value       = aws_route53_zone.default.arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,7 @@ variable "name" {
 variable "tags" {
   type        = map(string)
   description = "Map of tags to set on Terraform created resources"
+  default     = {}
 }
 
 variable "vpc" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,10 @@
 terraform {
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "> 4.0"
+      source                = "hashicorp/aws"
+      version               = ">= 4.0"
+      configuration_aliases = [aws.kms]
     }
   }
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.0"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,9 @@
 terraform {
-  required_version = ">= 0.13.1"
-
   required_providers {
-    aws = ">= 3.67"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "> 4.0"
+    }
   }
+  required_version = ">= 1.3.0"
 }


### PR DESCRIPTION
* Bump aws provider version
* Remove depricated provider configuration to prevent:
```
Initializing modules...
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.
╷
│ Error: Module is incompatible with count, for_each, and depends_on
│ 
│   on eu-central-1.tf line 14, in module "tld_eu_central_1":
│   14:   for_each = local.domains
│ 
│ The module at module.tld_eu_central_1 is a legacy module which contains its own local
│ provider configurations, and so calls to it may not use the count, for_each, or depends_on
│ arguments.
│ 
│ If you also control the module
│ "git::https://github.com/schubergphilis/terraform-aws-mcaf-route53-zones.git?ref=upgrade-for-tf-compatibility",
│ consider updating this module to instead expect provider configurations to be passed by
│ its caller.
```