### PR TITLE
fix: adds missing config alias for AWS provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       version               = ">= 3.67"
-      configuration_aliases = [aws.kms]
+      configuration_aliases = [aws.kms, aws.dns_query_logging]
     }
   }
 


### PR DESCRIPTION
Adds missing configuration alias to prevent the following warning message:

```
│ Warning: Reference to undefined provider
│ 
│   on route53.tf line 60, in module "stack_delegated_zones":
│   60:   providers = { aws.kms = aws.us-east-1, aws.dns_query_logging = aws.us-east-1 }
│ 
│ There is no explicit declaration for local provider name
│ "aws.dns_query_logging" in module.stack_delegated_zones, so Terraform is
│ assuming you mean to pass a configuration for "hashicorp/aws".
│ 
│ If you also control the child module, add a required_providers entry named
│ "aws.dns_query_logging" with the source address "hashicorp/aws".
```