### PR TITLE
Make aws_cloudwatch_log_resource_policy configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to set on Terraform created resources | `map(string)` | n/a | yes |
 | <a name="input_comment"></a> [comment](#input\_comment) | Comment for the hosted zone | `string` | `null` | no |
 | <a name="input_delegation_set_id"></a> [delegation\_set\_id](#input\_delegation\_set\_id) | Delegation set ID whose NS records will be used by the hosted zone; conflicts with `var.vpc` as delegation sets can only be used with public zones | `string` | `null` | no |
-| <a name="input_dns_query_logging"></a> [dns\_query\_logging](#input\_dns\_query\_logging) | Enable public DNS query logging for the hosted zone | <pre>object({<br>    retention_in_days = number<br>  })</pre> | `null` | no |
+| <a name="input_dns_query_logging"></a> [dns\_query\_logging](#input\_dns\_query\_logging) | Enable public DNS query logging for the hosted zone | <pre>object({<br>    retention_in_days          = number<br>    create_log_resource_policy = optional(bool, true)<br>  })</pre> | `null` | no |
 | <a name="input_dnssec"></a> [dnssec](#input\_dnssec) | Set to true to enable DNSSEC signing | `bool` | `false` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Set to true to destroy all records when destroying the managed zone | `bool` | `false` | no |
 | <a name="input_kms_signing_key_settings"></a> [kms\_signing\_key\_settings](#input\_kms\_signing\_key\_settings) | KMS key settings used for zone signing | <pre>object({<br>    deletion_window_in_days = optional(number, 30)<br>  })</pre> | <pre>{<br>  "deletion_window_in_days": 30<br>}</pre> | no |
@@ -69,7 +69,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_route53_zone_arn"></a> [route53\_zone\_arn](#output\_route53\_zone\_arn) | ARN of Route53 zone |
+| <a name="output_route53_zone_id"></a> [route53\_zone\_id](#output\_route53\_zone\_id) | Zone ID of Route53 zone |
 | <a name="output_route53_zone_name"></a> [route53\_zone\_name](#output\_route53\_zone\_name) | Name of Route53 zone |
 | <a name="output_route53_zone_name_servers"></a> [route53\_zone\_name\_servers](#output\_route53\_zone\_name\_servers) | Name servers of Route53 zone |
-| <a name="output_route53_zone_zone_id"></a> [route53\_zone\_zone\_id](#output\_route53\_zone\_zone\_id) | Zone ID of Route53 zone |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Additionally, using this feature [requires an AWS provider](https://registry.ter
 
 Using this feature [requires an AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_query_log) in region `us-east-1`.
 
+Since there is a [hard limit](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html) on the amount of Resource policies (`aws_cloudwatch_log_resource_policy`), the creation of this can be disabled. If there are multiple hosted zones it's then better to create it outside this module. Can be disabled by specifying `create_log_resource_policy = false` in the `dns_query_logging`.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/dns_query_logging.tf
+++ b/dns_query_logging.tf
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_log_group" "dns_query_logging" {
 }
 
 resource "aws_cloudwatch_log_resource_policy" "dns_query_logging" {
-  count    = var.dns_query_logging != null ? 1 : 0
+  count    = try(var.dns_query_logging.create_log_resource_policy, false) ? 1 : 0
   provider = aws.dns_query_logging
 
   policy_document = data.aws_iam_policy_document.dns_query_logging[0].json

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "route53_zone_arn" {
   value       = aws_route53_zone.default.arn
 }
 
+output "route53_zone_id" {
+  description = "Zone ID of Route53 zone"
+  value       = aws_route53_zone.default.zone_id
+}
+
 output "route53_zone_name" {
   description = "Name of Route53 zone"
   value       = aws_route53_zone.default.name
@@ -11,9 +16,4 @@ output "route53_zone_name" {
 output "route53_zone_name_servers" {
   description = "Name servers of Route53 zone"
   value       = aws_route53_zone.default.name_servers
-}
-
-output "route53_zone_zone_id" {
-  description = "Zone ID of Route53 zone"
-  value       = aws_route53_zone.default.zone_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,8 @@ variable "delegation_set_id" {
 
 variable "dns_query_logging" {
   type = object({
-    retention_in_days = number
+    retention_in_days          = number
+    create_log_resource_policy = optional(bool, true)
   })
   default     = null
   description = "Enable public DNS query logging for the hosted zone"


### PR DESCRIPTION
This PR makes the creation of the `aws_cloudwatch_log_resource_policy` optional.

This is a configuration that is not tied to a resource and there is a hard limit (of 10) on an account/region. Added a configuration to disable this if wanted. This means it has to be configured outside this repo (which could be a good idea). 

We have 12 Hosted zones in an account, so trying to create 12 identitical Log Resource policies is not possible, and also a bit nonsense.

Also changed the output `route53_zone_zone_id` to `route53_zone_id` so it's more readable and in line with the rest.

Noticed this in a "bigger" account, created an issue and got the limit heads up there: https://github.com/hashicorp/terraform-provider-aws/issues/34683