### PR TITLE
feat!: Add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@ Terraform module to setup and manage route53 zones.
 
 To establish a chain of trust for DNSSEC, you must update the parent zone for your hosted zone with a DNSSEC 'DS' record.
 
-Additionally, using this feature [requires an AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_hosted_zone_dnssec) in region `us-east-1`.
-
 ## DNS Query Logging
-
-Using this feature [requires an AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_query_log) in region `us-east-1`.
 
 Since there is a [hard limit](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html) on the amount of Resource policies (`aws_cloudwatch_log_resource_policy`), the creation of this can be disabled. If there are multiple hosted zones it's then better to create it outside this module. Can be disabled by specifying `create_log_resource_policy = false` in the `dns_query_logging`.
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,13 @@ Since there is a [hard limit](https://docs.aws.amazon.com/AmazonCloudWatch/lates
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.67 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.67 |
-| <a name="provider_aws.dns_query_logging"></a> [aws.dns\_query\_logging](#provider\_aws.dns\_query\_logging) | >= 3.67 |
-| <a name="provider_aws.kms"></a> [aws.kms](#provider\_aws.kms) | >= 3.67 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 
@@ -41,10 +39,9 @@ No modules.
 | [aws_route53_key_signing_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_key_signing_key) | resource |
 | [aws_route53_query_log.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_query_log) | resource |
 | [aws_route53_zone.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
-| [aws_caller_identity.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.dns_query_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dnssec_signing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_region.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/dns_query_logging.tf
+++ b/dns_query_logging.tf
@@ -17,18 +17,18 @@ data "aws_iam_policy_document" "dns_query_logging" {
 }
 
 resource "aws_cloudwatch_log_group" "dns_query_logging" {
-  count    = var.dns_query_logging != null ? 1 : 0
-  provider = aws.dns_query_logging
+  count = var.dns_query_logging != null ? 1 : 0
 
+  region            = local.global_region
   name              = "/aws/route53/${aws_route53_zone.default.name}"
   kms_key_id        = var.dns_query_logging.kms_key_arn
   retention_in_days = var.dns_query_logging.retention_in_days
 }
 
 resource "aws_cloudwatch_log_resource_policy" "dns_query_logging" {
-  count    = try(var.dns_query_logging.create_log_resource_policy, false) ? 1 : 0
-  provider = aws.dns_query_logging
+  count = try(var.dns_query_logging.create_log_resource_policy, false) ? 1 : 0
 
+  region          = local.global_region
   policy_document = data.aws_iam_policy_document.dns_query_logging[0].json
   policy_name     = "route53-query-logging-policy-${aws_route53_zone.default.name}"
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,33 +1,19 @@
-// DNSSEC KMS keys must be created in us-east-1
-provider "aws" {
-  alias  = "kms"
-  region = "us-east-1"
-}
-
-provider "aws" {
-  alias  = "dns_query_logging"
-  region = "us-east-1"
-}
-
 // Test single zone
 module "one" {
-  source    = "../.."
-  providers = { aws = aws, aws.kms = aws.kms, aws.dns_query_logging = aws.dns_query_logging }
-  name      = "a.example.org"
+  source = "../.."
+  name   = "a.example.org"
 }
 
 // Test multiple zones using for_each
 module "for_each" {
-  for_each  = toset(["a", "b", "c"])
-  source    = "../.."
-  providers = { aws = aws, aws.kms = aws, aws.dns_query_logging = aws.dns_query_logging }
-  name      = "${each.key}.example.org"
+  for_each = toset(["a", "b", "c"])
+  source   = "../.."
+  name     = "${each.key}.example.org"
 }
 
 // Test zone with DNS query logging enabled
 module "query_logging" {
   source            = "../.."
-  providers         = { aws = aws, aws.kms = aws.kms, aws.dns_query_logging = aws.dns_query_logging }
   name              = "query.example.org"
   dns_query_logging = { retention_in_days = 30 }
 }

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.67"
+      version = "~> 6.0"
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  global_region = "us-east-1"
+}
+
 resource "aws_route53_zone" "default" {
   # https://github.com/bridgecrewio/checkov/issues/3562#issuecomment-1256892542
   #checkov:skip=CKV2_AWS_39: "Ensure Domain Name System (DNS) query logging is enabled for Amazon Route 53 hosted zones"

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,9 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source                = "hashicorp/aws"
-      version               = ">= 3.67"
-      configuration_aliases = [aws.kms, aws.dns_query_logging]
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
⚠️ **This introduces a breaking change as it requires at least v6 of the AWS provider.** ⚠️

## :hammer_and_wrench: Summary

This pull request updates the MCAF route53 Terraform module to to support the regional configuration of resources. Since DNSSEC and DNS Query logging both explicitly need to be configured in `us-east-1` this is now automatically configured. No other regional configuration is needed/possible (Route53 is global).

**Region configuration improvements:** 

* Removed provider Alias configuration. Region is now explicitly using `us-east-1`. This means that the AWS provider can be configured with any region to be used with this new version

## :rocket: Motivation

Using the new `region` attribute of resources removes the need to instantiate multiple AWS provider instances for using this module and ensures compatibility with the latest AWS provider.
